### PR TITLE
Add documentId and elementId to PTC_onshape_metadata extension schema

### DIFF
--- a/extensions/2.0/Vendor/PTC_onshape_metadata/README.md
+++ b/extensions/2.0/Vendor/PTC_onshape_metadata/README.md
@@ -20,14 +20,23 @@ This extension adds metadata information to the glTF model. While this extension
 ```javascript
 "extensions": {
     "PTC_onshape_metadata": {
+        "documentId" : "c5986491b733a231c220c65a",
+        "elementId" : "4c52322aa3d6c2699898a3fc",
         "id": ["JHD"],
         "hidden": true
-        }
+    }
 }
 ```
 
-This extension adds id and hidden to the glTF model:
+This extension adds documentId, elementId, id and hidden to the glTF model:
 
+### Document ID
+
+A string representing the ID of the Onshape document containing the element the GlTF was derived for.
+
+### Element ID
+
+A string representing the ID of the Onshape element the GlTF was derived for, such as a Part Studio element.
 
 ### ID
 

--- a/extensions/2.0/Vendor/PTC_onshape_metadata/schema/gltf.PTC_onshape_metadata.schema.json
+++ b/extensions/2.0/Vendor/PTC_onshape_metadata/schema/gltf.PTC_onshape_metadata.schema.json
@@ -7,12 +7,12 @@
     "properties": {
         "documentId" : {
             "type" : "string",
-            "minLength": 1,
+            "minLength": 24,
             "description" : "An identifier of the document this object relates to."
         },
         "elementId" : {
             "type" : "string",
-            "minLength": 1,
+            "minLength": 24,
             "description" : "An identifier for the element this object relates to."
         },
         "id": {

--- a/extensions/2.0/Vendor/PTC_onshape_metadata/schema/gltf.PTC_onshape_metadata.schema.json
+++ b/extensions/2.0/Vendor/PTC_onshape_metadata/schema/gltf.PTC_onshape_metadata.schema.json
@@ -5,6 +5,16 @@
     "description": "glTF extension for specifying IDs and visibility.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
     "properties": {
+        "documentId" : {
+            "type" : "string",
+            "minLength": 1,
+            "description" : "An identifier of the document this object relates to."
+        },
+        "elementId" : {
+            "type" : "string",
+            "minLength": 1,
+            "description" : "An identifier for the element this object relates to."
+        },
         "id": {
             "anyOf":[
                 {


### PR DESCRIPTION
Add elementId and documentId to the schema and example in README.md